### PR TITLE
Saffron fixes and HTML.scriptingEnabled

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,22 @@ as a js object.
 This is useful as Saffron does not have been converted to ES6 yet and the compiler
 throws errors when importing dynamic source files (js files).
 
+```typescript
+loader: async (filepath: string) => {
+    let data: any;
+    if (filepath.endsWith(".json")) {
+        data = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+    } else {
+        data = await import(filepath);
+        data = {...data.default};
+    }
+
+    return data;
+}
+```
+
+It can also be used to modify the file's content before Saffron can parse them.
+
 ### `includeOnly`
 Default value: `[]`
 

--- a/docs/source_files/html.md
+++ b/docs/source_files/html.md
@@ -28,6 +28,11 @@ For example, for this HTML code the container will be `.the-container >`.
 </div>
 ```
 
+## `scriptingEnabled`
+Default: `true`
+
+From Cheerio documentation, If set to true, noscript element content will be parsed as text.
+
 ## `article`
 It will contain all the configuration needed to fill each article field.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@unistudents/saffron",
-    "version": "4.6.2",
+    "version": "4.7.0",
     "description": "A fairly intuitive & powerful framework that enables you to collect & save articles and news from all over the web. ",
     "license": "MIT",
     "homepage": "https://github.com/unistudents/saffron#readme",

--- a/src/components/ParserClass.ts
+++ b/src/components/ParserClass.ts
@@ -1,6 +1,6 @@
 import type {Instructions} from "./instructions";
 import type {Article} from "./article";
-import type {Utils} from "../modules/parsers/Utils";
+import type {Utils} from "./Utils";
 
 export abstract class ParserClass {
 

--- a/src/components/Utils.ts
+++ b/src/components/Utils.ts
@@ -1,11 +1,11 @@
 import cheerio from "cheerio";
-import type {Attachment} from "../../components/article";
+import type {Attachment} from "./article";
 import https from "https";
 import axios, {AxiosRequestConfig, AxiosResponse} from "axios";
-import type {ParserResult, SourceFile} from "../../components/types";
-import {Source} from "../../components/source";
-import {Job} from "../../components/job";
-import {Worker} from "../worker";
+import type {ParserResult, SourceFile} from "./types";
+import {Source} from "./source";
+import {Job} from "./job";
+import {Worker} from "../modules/worker";
 import striptags from "striptags";
 
 export class Utils {

--- a/src/components/config.ts
+++ b/src/components/config.ts
@@ -96,6 +96,7 @@ const defaultConfig: ConfigType = {
             } else {
                 try {
                     data = await import(filepath);
+                    data = {...data.default};
                 } catch (e: any) {
                     try {
                         data = require(filepath);

--- a/src/components/source.ts
+++ b/src/components/source.ts
@@ -61,7 +61,6 @@ export class Source {
         instructions.ignoreCertificates = source.ignoreCertificates ?? false;
 
         instructions.includeContentAttachments = source.includeContentAttachments ?? Config.getOption(ConfigOptions.INCLUDE_CNT_ATTACHMENTS, config);
-        instructions.includeContentAttachments = source.includeContentAttachments ?? Config.getOption(ConfigOptions.INCLUDE_CNT_ATTACHMENTS, config);
         instructions.textDecoder = source.encoding ? new TextDecoder(source.encoding) : new TextDecoder();
 
         instructions.url = [];

--- a/src/components/source.ts
+++ b/src/components/source.ts
@@ -61,6 +61,7 @@ export class Source {
         instructions.ignoreCertificates = source.ignoreCertificates ?? false;
 
         instructions.includeContentAttachments = source.includeContentAttachments ?? Config.getOption(ConfigOptions.INCLUDE_CNT_ATTACHMENTS, config);
+        instructions.includeContentAttachments = source.includeContentAttachments ?? Config.getOption(ConfigOptions.INCLUDE_CNT_ATTACHMENTS, config);
         instructions.textDecoder = source.encoding ? new TextDecoder(source.encoding) : new TextDecoder();
 
         instructions.url = [];

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,5 +1,5 @@
 import type {Article} from "./article";
-import type {Utils} from "../modules/parsers/Utils";
+import type {Utils} from "./Utils";
 import type {AxiosRequestConfig} from "axios";
 
 export type InstructionUrl = {
@@ -21,6 +21,7 @@ export type ScrapeDynamic = (utils: Utils, Article: any) => Promise<Article[]>;
 
 export type ScrapeHTML = {
     container: string;
+    scriptingEnabled?: boolean;
     skip?: ({
         selector?: string;
         text?: string;
@@ -29,7 +30,8 @@ export type ScrapeHTML = {
         position: number;
     })[];
     article: {
-        [field: 'title' | 'link' | 'content' | 'pubDate' | 'categories' | string]: {
+        // TODO: Only for categories add link field, to store directly in the categories links array
+        [field: 'title' | 'link' | 'content' | 'pubDate' | 'categories' | 'attachments' | 'thumbnail' | string]: {
             parent?: string;
 
             class?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export type {ConfigType} from "./components/config"
 export {Article} from "./components/article";
-export {Utils} from "./modules/parsers/Utils";
+export {Utils} from "./components/Utils";
 export {Job} from "./components/job"
 export {Source} from "./components/source"
 export {Instructions} from "./components/instructions";

--- a/src/modules/parsers/dynamic.parser.ts
+++ b/src/modules/parsers/dynamic.parser.ts
@@ -1,7 +1,7 @@
 import {ParserClass} from "../../components/ParserClass";
 import type {Instructions} from "../../components/instructions";
 import {Article} from "../../components/article";
-import type {Utils} from "./Utils";
+import type {Utils} from "../../components/Utils";
 import type {ScrapeDynamic, SourceScrape} from "../../components/types";
 
 export class DynamicParser extends ParserClass {

--- a/src/modules/parsers/rss.parser.ts
+++ b/src/modules/parsers/rss.parser.ts
@@ -46,12 +46,6 @@ export class RssParser extends ParserClass {
         const response: AxiosResponse = await utils.get(utils.url);
 
         const parser = new Parser({
-            timeout: utils.source.instructions.timeout,
-            maxRedirects: utils.source.instructions.maxRedirects,
-            headers: utils.source.instructions.headers as any,
-            requestOptions: {
-                rejectUnauthorized: !utils.source.instructions.ignoreCertificates
-            },
             customFields: {
                 // Make sure to request all the mentioned fields
                 item: requestFields

--- a/src/modules/parsers/rss.parser.ts
+++ b/src/modules/parsers/rss.parser.ts
@@ -2,8 +2,9 @@ import {ParserClass} from "../../components/ParserClass";
 import type {Instructions} from "../../components/instructions";
 import {Article} from "../../components/article";
 import Parser from "rss-parser";
-import type {Utils} from "./Utils";
+import type {Utils} from "../../components/Utils";
 import type {ScrapeRSS, SourceScrape} from "../../components/types";
+import type {AxiosResponse} from "axios";
 
 export class RssParser extends ParserClass {
 
@@ -42,7 +43,8 @@ export class RssParser extends ParserClass {
         // Default fields & extra fields
         const requestFields: string[] = ["title", "link", "content", "pubDate", "categories", ...extraFields];
 
-        // TODO: Replace request with axios, and library will do the parsing
+        const response: AxiosResponse = await utils.get(utils.url);
+
         const parser = new Parser({
             timeout: utils.source.instructions.timeout,
             maxRedirects: utils.source.instructions.maxRedirects,
@@ -56,7 +58,7 @@ export class RssParser extends ParserClass {
             }
         });
 
-        const feed = await parser.parseURL(utils.url);
+        const feed = await parser.parseString(response.data);
 
         const parsedArticles: Article[] = [];
         let count = 0;

--- a/src/modules/parsers/wordpress.v2.parser.ts
+++ b/src/modules/parsers/wordpress.v2.parser.ts
@@ -1,7 +1,7 @@
 import {ParserClass} from "../../components/ParserClass";
 import type {Instructions} from "../../components/instructions";
 import {Article} from "../../components/article";
-import type {Utils} from "./Utils";
+import type {Utils} from "../../components/Utils";
 import type {ScrapeWordPressV2, SourceScrape} from "../../components/types";
 
 export class WordpressV2Parser extends ParserClass {

--- a/src/modules/worker.ts
+++ b/src/modules/worker.ts
@@ -5,7 +5,7 @@ import type {Article} from "../components/article";
 import {ParserLoader} from "./parsers/ParserLoader";
 import {hashCode} from "../middleware/hashCode";
 import type {ParserResult} from "../components/types";
-import {Utils} from "./parsers/Utils";
+import {Utils} from "../components/Utils";
 import type {Saffron} from "../index";
 
 const sleep = ms => new Promise( res => setTimeout(res, ms));


### PR DESCRIPTION
### 💥 Breaking change
* RSS parser will use the default axios request as the other parsers.

### 🐛 Bug Fix
* Fixed ES6 default loader

### 🚀 Enhancement
* Added `scriptingEnabled` option for HTML parser

### 📝 Documentation
* Added `scriptingEnabled`
* Added example for configuration option`loader`

### 🏡 Internal
* Increased version to `v4.7.0`
* Moved 'Utils' to components folder

### Committers: 1
* @JexSrs