### PR TITLE
Fixed enchanted rss and added includeCategoryUrlsIn option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,12 @@ Default value: `true`
 
 If the generated article's attachments will contain the extracted urls from article's content.
 
+### `articles.includeCategoryUrlsIn`
+Default value: `categories`
+
+Accepted values are `categories` or `extras`.
+THis field will specify where to store the categories mentioned in the [`url`](./source_files/source_file.md#url) field of the source file.
+
 ## `scheduler`
 
 ### `jobsInterval`

--- a/docs/source_files/source_file.md
+++ b/docs/source_files/source_file.md
@@ -127,6 +127,14 @@ If the generated article's attachments will contain the extracted urls from arti
 
 This option will override the configuration option [`articles.includeContentAttachments`](../configuration#articlesincludeContentAttachments).
 
+### `includeCategoryUrlsIn`
+Default value: `categories`
+
+Accepted values are `categories` or `extras`.
+THis field will specify where to store the categories mentioned in the [`url`](#url) field of the source file.
+
+This option will override the configuration option [`articles.includeCategoryUrlsIn`](../configuration#articlesincludeCategoryUrlsIn).
+
 ### `enconding`
 The encoding of the website.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@unistudents/saffron",
-    "version": "4.7.0",
+    "version": "4.8.0",
     "description": "A fairly intuitive & powerful framework that enables you to collect & save articles and news from all over the web. ",
     "license": "MIT",
     "homepage": "https://github.com/unistudents/saffron#readme",

--- a/src/components/config.ts
+++ b/src/components/config.ts
@@ -26,6 +26,7 @@ export type ConfigType = {
         articles: Partial<{
             amount: number;
             includeContentAttachments: boolean;
+            includeCategoryUrlsIn: 'categories' | 'extras';
         }>;
     }>;
     scheduler: Partial<{
@@ -75,11 +76,12 @@ export enum ConfigOptions {
     EVENT_DELAY = 21,
     NEW_ARTICLES = 22,
     INCLUDE_CNT_ATTACHMENTS = 23,
-    MAX_REDIRECTS = 23,
-    DELAY_BETWEEN_REQUESTS = 24,
+    INCLUDE_CAT_URL = 24,
     AXIOS_REQUEST_CONFIG = 25,
     SCAN_SUB_FOLDERS = 26,
     SOURCE_LOADER = 27,
+    MAX_REDIRECTS = 28,
+    DELAY_BETWEEN_REQUESTS = 29,
 }
 
 const defaultConfig: ConfigType = {
@@ -121,7 +123,8 @@ const defaultConfig: ConfigType = {
         },
         articles: {
             amount: 30,
-            includeContentAttachments: true
+            includeContentAttachments: true,
+            includeCategoryUrlsIn: 'categories'
         }
     },
     scheduler: {
@@ -179,7 +182,7 @@ export class Config {
                 return conf.sources?.includeOnly;
             case ConfigOptions.SOURCES_EXCLUDE:
                 return conf.sources?.exclude;
-                case ConfigOptions.SOURCE_LOADER:
+            case ConfigOptions.SOURCE_LOADER:
                 return conf.sources?.loader;
 
             case ConfigOptions.WORKER_NODES:
@@ -199,6 +202,8 @@ export class Config {
                 return conf.workers?.articles?.amount;
             case ConfigOptions.INCLUDE_CNT_ATTACHMENTS:
                 return conf.workers?.articles?.includeContentAttachments;
+            case ConfigOptions.INCLUDE_CAT_URL:
+                return conf.workers?.articles?.includeCategoryUrlsIn;
 
             case ConfigOptions.JOB_INT:
                 return conf.scheduler?.jobsInterval;
@@ -305,6 +310,11 @@ export class Config {
             throw new Error('ConfigurationException Option workers.articles.amount is not valid, requirements(type = number, positive)');
         if (typeof this.config.workers.articles.includeContentAttachments !== 'boolean')
             throw new Error('ConfigurationException Option workers.articles.includeContentAttachments is not valid, requirements(type = boolean)');
+        if (typeof this.config.workers.articles.includeCategoryUrlsIn !== 'undefined'
+            && this.config.workers.articles.includeCategoryUrlsIn !== 'categories'
+            && this.config.workers.articles.includeCategoryUrlsIn !== 'extras'
+        )
+            throw new Error('ConfigurationException Option workers.articles.includeCategoryUrlsIn is not valid, requirements(type = string, =categories, =extras)');
 
         if (typeof this.config.scheduler !== 'object' || Array.isArray(this.config.scheduler))
             throw new Error('ConfigurationException Option block scheduler is not valid, requirements(type = object)');

--- a/src/components/instructions.ts
+++ b/src/components/instructions.ts
@@ -21,6 +21,7 @@ export class Instructions {
 
     declare textDecoder: TextDecoder;
     declare includeContentAttachments: boolean;
+    declare includeCategoryUrlsIn: 'categories' | 'extras';
     declare amount: number;
 
     declare html: ScrapeHTML;

--- a/src/components/source.ts
+++ b/src/components/source.ts
@@ -61,6 +61,11 @@ export class Source {
         instructions.ignoreCertificates = source.ignoreCertificates ?? false;
 
         instructions.includeContentAttachments = source.includeContentAttachments ?? Config.getOption(ConfigOptions.INCLUDE_CNT_ATTACHMENTS, config);
+
+        if (source.includeCategoryUrlsIn != undefined && source.includeCategoryUrlsIn !== 'categories' && source.includeCategoryUrlsIn !== 'extras')
+            throw new Error('SourceException [${source.filename}] Field includeCategoryUrlsIn is not valid, requirements(type = string, =categories, =extras)');
+        instructions.includeCategoryUrlsIn = source.includeCategoryUrlsIn ?? Config.getOption(ConfigOptions.INCLUDE_CAT_URL, config);
+
         instructions.textDecoder = source.encoding ? new TextDecoder(source.encoding) : new TextDecoder();
 
         instructions.url = [];

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -100,6 +100,7 @@ export type SourceFile = {
     amount?: number;
     encoding?: string;
     includeContentAttachments?: boolean;
+    includeCategoryUrlsIn?: 'categories' | 'extras';
 
     extra?: any;
 } & ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,7 @@ export {Source} from "./components/source"
 export {Instructions} from "./components/instructions";
 export {Saffron} from "./saffron";
 export {Serializer, pack, unpack} from "./middleware/serializer";
+
+// TODO: Add source file templates?
+//   A template folder, where a source file can extend to. Will contain the same fields
+//   as a source file, but it will not check if the fields exist.

--- a/src/modules/worker.ts
+++ b/src/modules/worker.ts
@@ -43,8 +43,16 @@ export class Worker {
             if(!Array.isArray(articles))
                 throw new Error('did not return an array of articles');
 
+            const includeCategoryUrlsIn = utils.source.instructions.includeCategoryUrlsIn;
             const categoriesFromAliases = utils.aliases.map((alias: string) => ({name: alias, links: [utils.url]}));
-            articles.forEach(article => article.pushCategories(categoriesFromAliases));
+            switch (includeCategoryUrlsIn) {
+                case "categories":
+                    articles.forEach(article => article.pushCategories(categoriesFromAliases));
+                    break;
+                case "extras":
+                    articles.forEach(articles => articles.addExtra('__url_categories', categoriesFromAliases));
+                    break;
+            }
 
             results.push({
                 aliases: pair.aliases,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -21,6 +21,7 @@ describe('Configuration', function () {
         expect(c.workers?.requests?.maxRedirects).to.equal(5);
         expect(c.workers?.articles?.amount).to.equal(30);
         expect(c.workers?.articles?.includeContentAttachments).to.equal(true);
+        expect(c.workers?.articles?.includeCategoryUrlsIn).to.equal('categories');
         expect(c.scheduler?.jobsInterval).to.equal(3600000);
         expect(c.scheduler?.heavyJobFailureInterval).to.equal(86400000);
         expect(c.scheduler?.noResponseThreshold).to.equal(2);

--- a/test/parsers.html.test.ts
+++ b/test/parsers.html.test.ts
@@ -13,9 +13,13 @@ describe("HTML parser", function () {
             for (const article of obj.articles) {
                 expect(article.source).to.equal('html1-source');
 
-                const cat = article.categories.find(cat => cat.name === 'Γενικές Ανακοινώσεις');
-                expect(cat).to.not.be.undefined;
-                expect(cat!.links).to.deep.equal(['http://127.0.0.1:3000/html1']);
+                const invCat = article.categories?.find(cat => cat.name === 'Γενικές Ανακοινώσεις');
+                expect(invCat).to.be.undefined;
+
+                expect(article.extras['__url_categories']).to.not.be.undefined.not;
+                const cat = article.extras['__url_categories'].find(cat => cat.name === 'Γενικές Ανακοινώσεις');
+                expect(cat).to.not.be.undefined.not;
+                expect(cat.links).to.deep.equal(['http://127.0.0.1:3000/html1']);
             }
 
             const article = obj.articles[0];

--- a/test/sources/html/html1.json
+++ b/test/sources/html/html1.json
@@ -5,6 +5,7 @@
     "name": "html1-source",
     "type": "html",
     "ignoreCertificates": true,
+    "includeCategoryUrlsIn": "extras",
     "scrape": {
         "container": ".catItemView",
         "endPoint": "unipi.gr",


### PR DESCRIPTION
### 🐛 Bug Fix
* Removed undefined article fields from article.extras when scraping using the RSS parser

### 🚀 Enhancement
* Added `includeCategoryUrlsIn` configuration and source file option
* In RSS parser the fields `media:thumbnail` and `media:content` will be set to thumbnail if they exist

### 📝 Documentation
* Updated docs to match new features

### 🏡 Internal
* Increased version to v4.8.0
* Updated tests to test new features

### Committers: 1
* @JexSrs 